### PR TITLE
Updated all defense units, tooltip changes and new filters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+          extensions: imagick, gd
 
       - name: Composer - Install dependencies
         run: composer install -n --prefer-dist --no-progress
@@ -76,6 +77,7 @@ jobs:
           php artisan key:generate
           php artisan dusk:chrome-driver --detect
           php artisan migrate:fresh
+          chmod -R 0755 public/
           chmod -R 0755 vendor/laravel/dusk/bin/
           ./vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &
           php artisan serve > /dev/null 2>&1 &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated all defense units for old towers.
 
+### Fixed
+- Input Text for search is now white in dark mode.
+
 ## [2.0.3] - 2021-08-12
 ### Fixed
 - Pagination do not used the selected filters. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Tooltip for Towers.
 - Defense Units in Tower Tooltip.
+- Rifted, Hardcore and AFK Able filter for builds.
 
 ### Changed
 - Updated all defense units for old towers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.3 - 2021-08-12]
+## [2.0.4] - 2022-09-23
+### Added
+- Tooltip for Towers.
+- Defense Units in Tower Tooltip.
+
+### Changed
+- Updated all defense units for old towers.
+
+## [2.0.3] - 2021-08-12
 ### Fixed
 - Pagination do not used the selected filters. 
 
-## [2.0.2 - 2021-08-12]
+## [2.0.2] - 2021-08-12
 ### Added
 - Multiple Filter for Game Modes and Difficulties.
 ### Fixed

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -17,7 +17,7 @@ class AuthController extends AbstractController {
 	}
 
 	public function auth(Request $request) {
-		if ( $request->query('debug') && app()->environment('local') ) {
+		if ( $request->query('debug') && app()->isLocal() ) {
 			// /api/auth/steam?debug=steamID
 			/** @var SteamUser $user */
 			$user = SteamUser::query()->find($request->query('debug'));

--- a/app/Http/Middleware/LocaleMiddleware.php
+++ b/app/Http/Middleware/LocaleMiddleware.php
@@ -7,29 +7,31 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 
-class LocaleMiddleware {
+class LocaleMiddleware
+{
 	/**
 	 * Handle an incoming request.
 	 *
 	 * @param \Illuminate\Http\Request $request
-	 * @param \Closure                 $next
+	 * @param \Closure $next
 	 *
 	 * @return mixed
 	 */
-	public function handle(Request $request, Closure $next) {
+	public function handle(Request $request, Closure $next)
+	{
 		$supportedLocales = Locale::getLocales();
 
 		$requestedLocale = $request->header('accept-language');
 		$locale = $supportedLocales[config('app.locale')] ?? reset($supportedLocales); // get default locale or first supportedLocale
 
 		// check if requestedLocale is a supported locale
-		if ( isset($supportedLocales[$requestedLocale]) ) {
+		if (isset($supportedLocales[$requestedLocale])) {
 			$locale = $supportedLocales[$requestedLocale];
 		}
-		// no directly locale name given, try to find a supported locale from header
 		else {
-			foreach ( explode(',', str_replace(';', ',', $requestedLocale)) as $value ) {
-				if ( isset($supportedLocales[$value]) ) {
+			// no directly locale name given, try to find any supported locale from header value
+			foreach (explode(',', str_replace(';', ',', $requestedLocale)) as $value) {
+				if (isset($supportedLocales[$value])) {
 					$locale = $supportedLocales[$value];
 					break;
 				}

--- a/app/Laravel/Builder.php
+++ b/app/Laravel/Builder.php
@@ -7,14 +7,16 @@ use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Builder as BaseBuilder;
 use Illuminate\Pagination\Paginator;
 
-class Builder extends BaseBuilder {
-	public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $currentPage = null) {
-		$currentPage = $currentPage ? : Paginator::resolveCurrentPage($pageName);
+class Builder extends BaseBuilder
+{
+	public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+	{
+		$page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-		$perPage = $perPage ? : $this->model->getPerPage();
+		$perPage = $perPage ?: $this->model->getPerPage();
 
 		$items = ($total = $this->toBase()->getCountForPagination())
-			? $this->forPage($currentPage, $perPage)->get($columns)
+			? $this->forPage($page, $perPage)->get($columns)
 			: $this->model->newCollection();
 
 		$options = [
@@ -23,11 +25,12 @@ class Builder extends BaseBuilder {
 		];
 
 		return Container::getInstance()->makeWith(SimplePaginator::class, compact(
-			'items', 'total', 'perPage', 'currentPage', 'options'
+			'items', 'total', 'perPage', 'page', 'options'
 		));
 	}
 
-	protected function simplePaginator($items, $perPage, $currentPage, $options) {
+	protected function simplePaginator($items, $perPage, $currentPage, $options)
+	{
 		return Container::getInstance()->makeWith(SimplePaginator::class, compact(
 			'items', 'perPage', 'currentPage', 'options'
 		));

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -12,6 +12,7 @@ use App\Models\Traits\HasSteamUser;
 use App\Models\Traits\TLikeable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Facades\Log;
 
 /**
  * @property-read int $ID
@@ -224,7 +225,7 @@ class Build extends AbstractModel implements ILikeableModel
 			});
 	}
 
-	public function generateThumbnail()
+	public function generateThumbnail() : bool
 	{
 		$mapResource = imagecreatefrompng($this->map->getPublicPath());
 		if ( !$mapResource ) {
@@ -285,12 +286,12 @@ class Build extends AbstractModel implements ILikeableModel
 		);
 	}
 
-	public function getPublicThumbnailPath()
+	public function getPublicThumbnailPath() : string
 	{
 		return public_path('assets/images/thumbnail/'.$this->ID.'.png');
 	}
 
-	public function getNotificationData()
+	public function getNotificationData() : array
 	{
 		return [
 			'ID' => $this->ID,

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -39,7 +39,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
  * @property-read Map $map
  * @property-read BuildWatch $watchStatus
  */
-class Build extends AbstractModel implements ILikeableModel {
+class Build extends AbstractModel implements ILikeableModel
+{
 	use HasFactory;
 	use HasSteamUser;
 	use TLikeable;
@@ -93,35 +94,43 @@ class Build extends AbstractModel implements ILikeableModel {
 		'gameModeID',
 	];
 
-	public function watchStatus() {
+	public function watchStatus()
+	{
 		return $this->hasOne(BuildWatch::class, 'buildID', 'ID')->where('steamID', auth()->id() ?? 0);
 	}
 
-	public function map() {
+	public function map()
+	{
 		return $this->hasOne(Map::class, 'ID', 'mapID');
 	}
 
-	public function difficulty() {
+	public function difficulty()
+	{
 		return $this->hasOne(Difficulty::class, 'ID', 'difficultyID');
 	}
 
-	public function gameMode() {
+	public function gameMode()
+	{
 		return $this->hasOne(GameMode::class, 'ID', 'gameModeID');
 	}
 
-	public function waves() {
+	public function waves()
+	{
 		return $this->hasMany(BuildWave::class, 'buildID', 'ID');
 	}
 
-	public function heroStats() {
+	public function heroStats()
+	{
 		return $this->hasMany(BuildHeroStats::class, 'buildID', 'ID');
 	}
 
-	public function commentList() {
+	public function commentList()
+	{
 		return $this->hasMany(BuildComment::class, 'buildID', 'ID')->orderBy('date', 'desc');
 	}
 
-	public function addStats($stats) {
+	public function addStats($stats)
+	{
 		if ( !$this->ID ) {
 			return false;
 		}
@@ -134,7 +143,8 @@ class Build extends AbstractModel implements ILikeableModel {
 		return true;
 	}
 
-	public function scopeSort(Builder $query, $column = 'date', $direction = 'asc') {
+	public function scopeSort(Builder $query, $column = 'date', $direction = 'asc')
+	{
 		if ( $column === null && $direction === null ) {
 			$column = 'date';
 			$direction = 'desc';
@@ -152,7 +162,8 @@ class Build extends AbstractModel implements ILikeableModel {
 		}
 	}
 
-	public function scopeSearch(Builder $query, array $searchParameters) {
+	public function scopeSearch(Builder $query, array $searchParameters)
+	{
 		$searchParameters = array_merge([
 			'isDeleted' => 0,
 			'title' => null,
@@ -163,7 +174,7 @@ class Build extends AbstractModel implements ILikeableModel {
 		], $searchParameters);
 
 		$where = [
-			['isDeleted', '=', 0],
+			'isDeleted' => 0,
 		];
 
 		if ( $searchParameters['title'] ) {
@@ -192,15 +203,29 @@ class Build extends AbstractModel implements ILikeableModel {
 			}
 		}
 
-		$query->where($where)->where(function ($query) {
-			$query->where('buildStatus', '=', self::STATUS_PUBLIC);
-			if ( auth()->id() ) {
-				$query->orWhere($this->table.'.steamID', '=', auth()->id());
+		foreach ( ['hardcore', 'afkAble', 'rifted'] as $field ) {
+			if ( isset($searchParameters[$field]) && $searchParameters[$field] === 'true' ) {
+				$query->where([
+					$field => true,
+				]);
 			}
-		});
+		}
+
+		$query
+			->where($where)
+			->where(function ($query) {
+				$query->where('buildStatus', '=', self::STATUS_PUBLIC);
+
+				if ( auth()->id() ) {
+					$query->orWhere([
+						$this->table.'.steamID' => auth()->id(),
+					]);
+				}
+			});
 	}
 
-	public function generateThumbnail() {
+	public function generateThumbnail()
+	{
 		$mapResource = imagecreatefrompng($this->map->getPublicPath());
 		if ( !$mapResource ) {
 			return false;
@@ -260,11 +285,13 @@ class Build extends AbstractModel implements ILikeableModel {
 		);
 	}
 
-	public function getPublicThumbnailPath() {
+	public function getPublicThumbnailPath()
+	{
 		return public_path('assets/images/thumbnail/'.$this->ID.'.png');
 	}
 
-	public function getNotificationData() {
+	public function getNotificationData()
+	{
 		return [
 			'ID' => $this->ID,
 			'title' => $this->title,

--- a/app/Models/Hero.php
+++ b/app/Models/Hero.php
@@ -2,18 +2,26 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
 /**
- * @property-read int    $ID
+ * @property-read int $ID
  * @property-read string $name
- * @property-read int    $isHero
- * @property-read int    $isDisabled
+ * @property-read int $isHero
+ * @property-read int $isDisabled
  */
-class Hero extends AbstractModel {
+class Hero extends AbstractModel
+{
 	protected $table = 'hero';
 
 	protected $primaryKey = 'ID';
 
-	public function towers() {
+	protected $guarded = [];
+
+	public $timestamps = false;
+
+	public function towers(): HasMany
+	{
 		return $this->hasMany(Tower::class, 'heroClassID');
 	}
 }

--- a/app/Models/Hero.php
+++ b/app/Models/Hero.php
@@ -22,6 +22,6 @@ class Hero extends AbstractModel
 
 	public function towers(): HasMany
 	{
-		return $this->hasMany(Tower::class, 'heroClassID');
+		return $this->hasMany(Tower::class, 'heroClassID', 'ID');
 	}
 }

--- a/app/Models/Map.php
+++ b/app/Models/Map.php
@@ -2,26 +2,29 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
 /**
- * @property-read int    $ID
- * @property-read string $name
- * @property-read int    $units
- * @property-read int    $mapCategoryID
- *
- * @property-read string $image
+ * @property int $ID
+ * @property string $name
+ * @property int $units
+ * @property int $mapCategoryID
  */
-class Map extends AbstractModel {
+class Map extends AbstractModel
+{
 	protected $table = 'map';
 
 	protected $primaryKey = 'ID';
 
 	public $timestamps = false;
 
-	public function difficultyUnits() {
+	public function difficultyUnits(): HasMany
+	{
 		return $this->hasMany(MapAvailableUnit::class, 'mapID', 'ID');
 	}
 
-	public function getPublicPath() {
-		return public_path('assets/images/map/'.$this->name.'.png');
+	public function getPublicPath(): string
+	{
+		return public_path('assets/images/map/' . $this->name . '.png');
 	}
 }

--- a/app/Models/Tower.php
+++ b/app/Models/Tower.php
@@ -2,29 +2,38 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
 /**
- * @property-read int    $ID
- * @property-read int    $unitType (0 = du, 1 = mu)
- * @property-read int    $unitCost
- * @property-read int    $maxUnitCost
- * @property-read int    $manaCost
- * @property-read int    $heroClassID
- * @property-read string $name
- * @property-read int    $isResizable
- * @property-read int    $isRotatable
+ * @property int $ID
+ * @property int $unitType (0 = du, 1 = mu)
+ * @property int $unitCost
+ * @property int $maxUnitCost
+ * @property int $manaCost
+ * @property int $heroClassID
+ * @property string $name
+ * @property int $isResizable
+ * @property int $isRotatable
  *
- * @property-read Hero    $hero
+ * @property Hero $hero
  */
-class Tower extends AbstractModel {
+class Tower extends AbstractModel
+{
 	protected $table = 'tower';
 
 	protected $primaryKey = 'ID';
 
-	public function hero() {
+	public $timestamps = false;
+
+	protected $guarded = [];
+
+	public function hero(): HasOne
+	{
 		return $this->hasOne(Hero::class, 'ID', 'heroClassID');
 	}
 
-	public function getPublicPath() {
-		return public_path('assets/images/tower/'.$this->name.'.png');
+	public function getPublicPath(): string
+	{
+		return public_path('assets/images/tower/' . $this->name . '.png');
 	}
 }

--- a/app/Observers/BuildObserver.php
+++ b/app/Observers/BuildObserver.php
@@ -4,8 +4,12 @@ namespace App\Observers;
 
 use App\Models\Build;
 
-class BuildObserver {
-	public function deleting(Build $build) {
-		unlink($build->getPublicThumbnailPath());
+class BuildObserver
+{
+	public function deleting(Build $build)
+	{
+		if ( file_exists($build->getPublicThumbnailPath()) ) {
+			unlink($build->getPublicThumbnailPath());
+		}
 	}
 }

--- a/database/migrations/2022_09_23_223511_update_defense_units.php
+++ b/database/migrations/2022_09_23_223511_update_defense_units.php
@@ -1,0 +1,111 @@
+<?php
+
+use App\Models\Hero;
+use App\Models\Map;
+use App\Models\Tower;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateDefenseUnits extends Migration
+{
+	public function up()
+	{
+		// add act 4 maps
+		!Map::query()->where(['name' => 'theMill'])->first() && Map::query()->forceCreate([
+			'name' => 'theMill',
+			'units' => 140,
+			'mapCategoryID' => 1,
+		]);
+		!Map::query()->where(['name' => 'theOutpost'])->first() && Map::query()->forceCreate([
+			'name' => 'theOutpost',
+			'units' => 140,
+			'mapCategoryID' => 1,
+		]);
+		!Map::query()->where(['name' => 'theKeep'])->first() && Map::query()->forceCreate([
+			'name' => 'theKeep',
+			'units' => 145,
+			'mapCategoryID' => 1,
+		]);
+
+		// add new hero
+		/** @var Hero $hero */
+		$hero = Hero::query()->where(['name' => 'warden'])->first() ?? Hero::query()->create([
+			'ID' => 6,
+			'name' => 'warden',
+			'isHero' => true,
+			'isDisabled' => false,
+		]);
+
+		// add new towers
+		$newTowers = [
+			'rootsOfPurity' => [
+				'ID' => 26,
+				'manaCost' => 20,
+				'unitCost' => 1,
+				'isRotatable' => false,
+			],
+			'wispDen' => [
+				'ID' => 27,
+				'manaCost' => 50,
+				'unitCost' => 4,
+				'isRotatable' => false,
+			],
+			'beamingBlossom' => [
+				'ID' => 28,
+				'manaCost' => 70,
+				'unitCost' => 5,
+				'isRotatable' => true,
+			],
+			'shroomyPit' => [
+				'ID' => 29,
+				'manaCost' => 40,
+				'unitCost' => 3,
+				'isRotatable' => false,
+			],
+			'sludgeLauncher' => [
+				'ID' => 30,
+				'manaCost' => 120,
+				'unitCost' => 7,
+				'isRotatable' => true,
+			],
+		];
+
+		foreach ( $newTowers as $towerName => $values ) {
+			if ( Tower::query()->where(['name' => $towerName])->first() ) {
+				continue;
+			}
+
+			$hero->towers()->create(array_merge([
+				'unitType' => 0,
+				'maxUnitCost' => 0,
+				'heroClassID' => $hero->getKey(),
+				'name' => $towerName,
+				'isResizable' => false,
+			], $values));
+		}
+
+		// update tower defense unit values
+		$updatedTowers = [
+			// squire
+			'spikedBlockade' => 1,
+			'harpoonTurret' => 5,
+			'bouncerBlockade' => 1,
+			'sliceNDiceBlockade' => 4,
+			// apprentice
+			'magicMissileTower' => 2,
+			// series
+			'overclockBeam' => 3,
+			// monk
+			'strengthDrainAura' => 4,
+		];
+
+		foreach ( $updatedTowers as $towerName => $newUnits ) {
+			Tower::query()->where(['name' => $towerName])->update([
+				'unitCost' => $newUnits,
+			]);
+		}
+	}
+
+	public function down()
+	{
+	}
+}

--- a/database/migrations/2022_09_23_223511_update_defense_units.php
+++ b/database/migrations/2022_09_23_223511_update_defense_units.php
@@ -74,10 +74,10 @@ class UpdateDefenseUnits extends Migration
 				continue;
 			}
 
-			$hero->towers()->create(array_merge([
+			Tower::query()->create(array_merge([
+				'heroClassID' => 6,
 				'unitType' => 0,
 				'maxUnitCost' => 0,
-				'heroClassID' => $hero->getKey(),
 				'name' => $towerName,
 				'isResizable' => false,
 			], $values));

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "name": "dda-builds-2",
     "scripts": {
         "dev-hot": "mix watch --hot",
-        "dev-php": "php artisan serve --host 0.0.0.0",
         "build": "mix --production",
         "eslint": "eslint -c .eslintrc.json --ext .js,.vue resources/src/",
         "eslint-fix": "eslint -c .eslintrc.json --ext .js,.vue resources/src/ --fix"

--- a/resources/src/utils/string.js
+++ b/resources/src/utils/string.js
@@ -1,24 +1,36 @@
-function ucfirst(string) {
-	if (Array.isArray(string)) {
-		return string.map((str) => ucfirst(str));
+function ucfirst(value) {
+	if ( value === null ) {
+		return '';
+	}
+	else if (Array.isArray(value)) {
+		return value.map((str) => ucfirst(str));
+	}
+	else if (typeof value === 'boolean') {
+		value = value.toString();
 	}
 
-	return string.substr(0, 1).toUpperCase() + string.substr(1);
+	return value.substring(0, 1).toUpperCase() + value.substring(1);
 }
 
-function lcfirst(string) {
-	if (Array.isArray(string)) {
-		return string.map((str) => lcfirst(str));
+function lcfirst(value) {
+	if ( value === null ) {
+		return '';
+	}
+	else if (Array.isArray(value)) {
+		return value.map((str) => lcfirst(str));
+	}
+	else if (typeof value === 'boolean') {
+		return value.toString();
 	}
 
-	return string.substr(0, 1).toLowerCase() + string.substr(1);
+	return value.substring(0, 1).toLowerCase() + value.substring(1);
 }
 
 function formatSEOTitle(title) {
 	title = title
 		.toLowerCase()
 		.replace(/[^\p{L}\p{N}]+/ug, '-')
-		.substr(0, 80);
+		.substring(0, 80);
 	if (title[title.length - 1] === '-') {
 		title = title.substr(0, title.length - 1);
 	}

--- a/resources/src/views/Build/BuildAddView.vue
+++ b/resources/src/views/Build/BuildAddView.vue
@@ -165,7 +165,7 @@
 												:data-class="hero.ID"
 												:data-tower="tower.ID"
 												class="tower-container pointer dummy">
-												<img :src="'/assets/images/tower/' + tower.name + '.png'" :title="$t('tower.' + tower.name)" class="tower">
+												<img v-b-tooltip.hover="`${$t(`tower.${tower.name}`)} (${tower.unitCost})`" :src="`/assets/images/tower/${tower.name}.png`" class="tower">
 											</div>
 										</div>
 									</div>

--- a/resources/style/layout/dark.scss
+++ b/resources/style/layout/dark.scss
@@ -224,6 +224,10 @@ body.bg-dark {
 	}
 
 	// vue select design
+	.vs__search {
+		color: #B5AFA6;
+	}
+
 	.vs__dropdown-toggle {
 		min-height: 35px;
 


### PR DESCRIPTION
- i have updated all defense unit values for old towers (e.g. spiked blockade changed 3 to 1)
- tooltips on towers in build view
- some dark mode fixes
- new hardcore/rifted and afk able filter in build list

to execute the sql changes just run `php artisan migrate`  
only the defense units should be updated because the new map, hero and towers are already in the database.